### PR TITLE
Remove eclipse `.settings` folders.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+#Eclipse
+.settings
+
+#Maven
+target
+release.properties
+pom.xml.*

--- a/.settings/org.eclipse.jdt.core.prefs
+++ b/.settings/org.eclipse.jdt.core.prefs
@@ -1,6 +1,0 @@
-#Sat Feb 19 13:45:11 GMT 2011
-eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.5
-org.eclipse.jdt.core.compiler.compliance=1.5
-org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
-org.eclipse.jdt.core.compiler.source=1.5

--- a/.settings/org.eclipse.m2e.core.prefs
+++ b/.settings/org.eclipse.m2e.core.prefs
@@ -1,5 +1,0 @@
-#Sat Mar 12 16:03:01 GMT 2011
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/.settings/org.maven.ide.eclipse.prefs
+++ b/.settings/org.maven.ide.eclipse.prefs
@@ -1,8 +1,0 @@
-#Sat Feb 19 13:45:11 GMT 2011
-activeProfiles=
-eclipse.preferences.version=1
-fullBuildGoals=process-test-resources
-resolveWorkspaceProjects=true
-resourceFilterGoals=process-resources resources\:testResources
-skipCompilerPlugin=true
-version=1

--- a/com.github.rgladwell.android.tools/.settings/org.eclipse.jdt.core.prefs
+++ b/com.github.rgladwell.android.tools/.settings/org.eclipse.jdt.core.prefs
@@ -1,8 +1,0 @@
-#Fri May 27 16:37:05 BST 2011
-eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.5
-org.eclipse.jdt.core.compiler.compliance=1.5
-org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
-org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.5

--- a/com.github.rgladwell.android.tools/.settings/org.eclipse.m2e.core.prefs
+++ b/com.github.rgladwell.android.tools/.settings/org.eclipse.m2e.core.prefs
@@ -1,5 +1,0 @@
-#Fri May 27 16:39:28 BST 2011
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/com.googlecode.eclipse.m2e.android.aggregator/.settings/org.eclipse.m2e.core.prefs
+++ b/com.googlecode.eclipse.m2e.android.aggregator/.settings/org.eclipse.m2e.core.prefs
@@ -1,5 +1,0 @@
-#Sun Jul 17 20:02:47 BST 2011
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/com.googlecode.eclipse.m2e.android.feature/.settings/org.eclipse.m2e.core.prefs
+++ b/com.googlecode.eclipse.m2e.android.feature/.settings/org.eclipse.m2e.core.prefs
@@ -1,5 +1,0 @@
-#Sat Mar 12 16:02:51 GMT 2011
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/com.googlecode.eclipse.m2e.android.feature/.settings/org.maven.ide.eclipse.prefs
+++ b/com.googlecode.eclipse.m2e.android.feature/.settings/org.maven.ide.eclipse.prefs
@@ -1,8 +1,0 @@
-#Thu Dec 02 21:22:26 GMT 2010
-activeProfiles=
-eclipse.preferences.version=1
-fullBuildGoals=process-test-resources
-resolveWorkspaceProjects=true
-resourceFilterGoals=process-resources resources\:testResources
-skipCompilerPlugin=true
-version=1

--- a/com.googlecode.eclipse.m2e.android.update/.settings/org.eclipse.m2e.core.prefs
+++ b/com.googlecode.eclipse.m2e.android.update/.settings/org.eclipse.m2e.core.prefs
@@ -1,5 +1,0 @@
-#Sat Mar 12 16:02:56 GMT 2011
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/com.googlecode.eclipse.m2e.android.update/.settings/org.maven.ide.eclipse.prefs
+++ b/com.googlecode.eclipse.m2e.android.update/.settings/org.maven.ide.eclipse.prefs
@@ -1,8 +1,0 @@
-#Thu Dec 02 21:22:41 GMT 2010
-activeProfiles=
-eclipse.preferences.version=1
-fullBuildGoals=process-test-resources
-resolveWorkspaceProjects=true
-resourceFilterGoals=process-resources resources\:testResources
-skipCompilerPlugin=true
-version=1

--- a/com.googlecode.eclipse.m2e.android/.settings/org.eclipse.jdt.core.prefs
+++ b/com.googlecode.eclipse.m2e.android/.settings/org.eclipse.jdt.core.prefs
@@ -1,9 +1,0 @@
-#Sun Mar 13 13:39:46 GMT 2011
-eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.5
-org.eclipse.jdt.core.compiler.compliance=1.5
-org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
-org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
-org.eclipse.jdt.core.compiler.source=1.5

--- a/com.googlecode.eclipse.m2e.android/.settings/org.eclipse.m2e.core.prefs
+++ b/com.googlecode.eclipse.m2e.android/.settings/org.eclipse.m2e.core.prefs
@@ -1,5 +1,0 @@
-#Sat Mar 12 16:02:43 GMT 2011
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/com.googlecode.eclipse.m2e.android/.settings/org.maven.ide.eclipse.prefs
+++ b/com.googlecode.eclipse.m2e.android/.settings/org.maven.ide.eclipse.prefs
@@ -1,8 +1,0 @@
-#Thu Dec 02 21:21:11 GMT 2010
-activeProfiles=
-eclipse.preferences.version=1
-fullBuildGoals=process-test-resources
-resolveWorkspaceProjects=true
-resourceFilterGoals=process-resources resources\:testResources
-skipCompilerPlugin=true
-version=1


### PR DESCRIPTION
This removes all of the `.settings/` folders in the repo since they are local to each machine.

Personally I also choose not to include the `.project` and `.classpath` files either since the code should be independent of any IDE. Developers can just use the "Import existing Maven project" wizard in Eclipse or IntelliJ IDEA. However, if _any_ project is ever tied to an IDE it would be this one! I will leave it up to your discretion.
