### PR TITLE
"Discover new m2e connectors" requires Eclipse Marketplace

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,6 +91,8 @@ subtitle: Android Configurator for M2E Maven Integration for Eclipse
 	Open your POM and click on the "Plugin execution not covered by
 	lifecycle configuration" error. This will give you the option to <em>Discover
 		new m2e connectors</em>.
+		
+	Note: This requires having the Eclipse Marketplace installed.
 </p>
 
 <p>


### PR DESCRIPTION
If you don't realize that then it is _very_ frustrating and not at all clear that that is the reason. This is important because Eclipse Classic (widely used) doesn't come with the marketplace. Here are instructions for installing Eclipse Marketplace:

http://stackoverflow.com/a/8599843/175830
