### PR TITLE
Fix target platform artifact's version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
 						<artifact>
 							<groupId>me.gladwell.eclipse.m2e.android</groupId>
 							<artifactId>m2e-android</artifactId>
-							<version>0.4.3-SNAPSHOT</version>
+							<version>${project.version}</version>
 							<classifier>${target.platform}</classifier>
 						</artifact>
 					</target>


### PR DESCRIPTION
All *.target files are part of this project anyway and should be
referenced via the same version as the project itself. When
configuring target-platform-configuration plugin, set target
artifact's version using a variable 'project.version' instead of a
plain string.

It will make release process less error-prone (i.e., see commits
19ca84 and c5442b).
