### PR TITLE
Docs: Change 'Configuration' sub-menu to 'Configure'.

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@ subtitle: Android Configurator for M2E Maven Integration for Eclipse
 
 <p>
 	Then right-click on your project and select
-	<em>Configuration -&gt; Convert to Maven Project</em>.
+	<em>Configure -&gt; Convert to Maven Project</em>.
 </p>
 
 <p>


### PR DESCRIPTION
In Eclipse Juno, anyhow, the submenu is named 'Configure' not 'Configuration'.
