### PR TITLE
Ignore optional warnings in "gen" folder

### DIFF
--- a/me.gladwell.eclipse.m2e.android/src/main/java/me/gladwell/eclipse/m2e/android/configuration/MavenAndroidClasspathConfigurer.java
+++ b/me.gladwell.eclipse.m2e.android/src/main/java/me/gladwell/eclipse/m2e/android/configuration/MavenAndroidClasspathConfigurer.java
@@ -11,14 +11,21 @@ package me.gladwell.eclipse.m2e.android.configuration;
 import static java.io.File.separator;
 
 import java.io.File;
+import java.lang.reflect.Field;
+import java.util.Iterator;
 import java.util.List;
 
 import me.gladwell.eclipse.m2e.android.project.AndroidProject;
+import me.gladwell.eclipse.m2e.android.project.MavenAndroidProject;
 
+import org.apache.maven.model.Plugin;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Path;
+import org.eclipse.jdt.core.IClasspathAttribute;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
@@ -32,7 +39,64 @@ public class MavenAndroidClasspathConfigurer implements AndroidClasspathConfigur
 
 	private static final String ANDROID_GEN_FOLDER = "gen";
     public static final String ANDROID_CLASSES_FOLDER = "bin" + separator + "classes";
+    
+    private static final String ANDROID_MAVEN_PLUGIN_GROUP_ID = "com.jayway.maven.plugins.android.generation2"; //$NON-NLS-1$
+    private static final String ANDROID_MAVEN_PLUGIN_ARTIFACT_ID = "android-maven-plugin"; //$NON-NLS-1$
+    private static final String IGNORE_WARNING_CONFIGURATION_NAME = "ignoreOptionalWarningsInGenFolder"; //$NON-NLS-1$
 
+	/**
+	 * Ignore any optional warning in the "gen" folder, iff the Maven plugin configuration
+	 * contains the correct flag 'ignoreOptionalWarningsInGenFolder'.
+	 * 
+	 * @param project
+	 * @param classpathDescriptor
+	 */
+    private static void ignoreOptionalWarningsOnSourceFolder(AndroidProject project, IClasspathEntryDescriptor classpathDescriptor) {
+    	String warningAttribute = null;
+    	// Test if the Eclipse IDE is able to change the "warning" flag (only since Indigo)
+    	try {
+    		Field field = IClasspathAttribute.class.getField("IGNORE_OPTIONAL_PROBLEMS"); //$NON-NLS-1$
+    		assert(field!=null);
+    		warningAttribute = field.get(null).toString();
+		}
+    	catch (Throwable _) {
+    		// The Eclipse platform does not provide the feature to change the warning flag.
+			return ;
+		}
+    	
+    	assert(warningAttribute!=null);
+    	
+		if (classpathDescriptor!=null && project instanceof MavenAndroidProject) {
+			MavenAndroidProject mavenAndroidProject = (MavenAndroidProject)project;
+			MavenProject mavenProject = mavenAndroidProject.getMavenProject();
+			if (mavenProject!=null && mavenProject.getBuildPlugins()!=null) {
+				List<Plugin> plugins = mavenProject.getBuildPlugins();
+				Iterator<Plugin> pluginIterator = plugins.iterator();
+				Xpp3Dom configuration = null;
+				while (configuration==null && pluginIterator.hasNext()) {
+					Plugin plugin = pluginIterator.next();
+					if ( ANDROID_MAVEN_PLUGIN_GROUP_ID.equals( plugin.getGroupId() ) &&
+						 ANDROID_MAVEN_PLUGIN_ARTIFACT_ID.equals(plugin.getArtifactId())) {
+						configuration = (Xpp3Dom) plugin.getConfiguration();
+					}
+				}
+
+				if (configuration!=null) {
+					configuration = configuration.getChild(IGNORE_WARNING_CONFIGURATION_NAME);
+					if (configuration!=null) {
+						String value = configuration.getValue();
+						if (value!=null && !value.isEmpty()) {
+							Boolean b = Boolean.parseBoolean(value.trim());
+							if (b!=null) {
+								classpathDescriptor.setClasspathAttribute(warningAttribute, b.toString());
+							}
+						}
+					}
+				}
+			}
+		}
+    }
+    
     public void addGenFolder(IJavaProject javaProject, AndroidProject project, IClasspathDescriptor classpath) {
         IFolder gen = javaProject.getProject().getFolder(ANDROID_GEN_FOLDER + File.separator);
         if (!gen.exists()) {
@@ -44,7 +108,8 @@ public class MavenAndroidClasspathConfigurer implements AndroidClasspathConfigur
         }
 
         if (!classpath.containsPath(new Path(ANDROID_GEN_FOLDER))) {
-			classpath.addSourceEntry(gen.getFullPath(), null, false);
+			IClasspathEntryDescriptor d = classpath.addSourceEntry(gen.getFullPath(), null, false);
+			ignoreOptionalWarningsOnSourceFolder(project, d);
 		}
 	}
 

--- a/me.gladwell.eclipse.m2e.android/src/main/java/me/gladwell/eclipse/m2e/android/project/JaywayMavenAndroidProject.java
+++ b/me.gladwell.eclipse.m2e.android/src/main/java/me/gladwell/eclipse/m2e/android/project/JaywayMavenAndroidProject.java
@@ -82,4 +82,8 @@ public class JaywayMavenAndroidProject implements MavenAndroidProject {
 				&& StringUtils.equals(dependency.getVersion(), mavenProject.getVersion());
 	}
 
+	public MavenProject getMavenProject() {
+		return this.mavenProject;
+	}
+	
 }

--- a/me.gladwell.eclipse.m2e.android/src/main/java/me/gladwell/eclipse/m2e/android/project/MavenAndroidProject.java
+++ b/me.gladwell.eclipse.m2e.android/src/main/java/me/gladwell/eclipse/m2e/android/project/MavenAndroidProject.java
@@ -8,6 +8,8 @@
 
 package me.gladwell.eclipse.m2e.android.project;
 
+import org.apache.maven.project.MavenProject;
+
 public interface MavenAndroidProject extends AndroidProject {
 
 	public String getGroup();
@@ -15,5 +17,11 @@ public interface MavenAndroidProject extends AndroidProject {
 	public String getVersion();
 
 	public boolean matchesDependency(Dependency dependency);
+
+	/** Replies the Maven project related to this Maven/Android project.
+	 * 
+	 * @return the reference to the Maven project.
+	 */
+	public MavenProject getMavenProject();
 
 }


### PR DESCRIPTION
When the configuration entry "ignoreOptionalWarningsInGenFolder" is set to "true" in the configuration of the Android Maven Plugin, the optional warnings in the "gen" folder are ignored by the Eclipse IDE.

This pull request provides an answer to issue #144.
