### PR TITLE
Support 'android' as well as 'com.google.android' as group ids.

### DIFF
--- a/me.gladwell.eclipse.m2e.android/src/main/java/me/gladwell/eclipse/m2e/android/project/JaywayMavenAndroidProject.java
+++ b/me.gladwell.eclipse.m2e.android/src/main/java/me/gladwell/eclipse/m2e/android/project/JaywayMavenAndroidProject.java
@@ -95,12 +95,17 @@ public class JaywayMavenAndroidProject implements MavenAndroidProject {
 
     private Dependency getAndroidDependency() {
         for(Artifact artifact : mavenProject.getArtifacts()) {
-            if(artifact.getGroupId().equals("com.google.android") && artifact.getArtifactId().equals("android")) {
+            if(isAndroidGroupId(artifact) && artifact.getArtifactId().equals("android")) {
                 return new MavenDependency(artifact);
             }
         }
         throw new ProjectConfigurationException("cannot find android dependency for project=[" + getName() + "]");
     }
+
+	private boolean isAndroidGroupId(Artifact artifact) {
+		return artifact.getGroupId().equals("com.google.android") ||
+		    artifact.getGroupId().equals("android");
+	}
 
 	public List<Dependency> getLibraryDependencies() {
 	    List<Dependency> results = new ArrayList<Dependency>(mavenProject.getArtifacts().size());


### PR DESCRIPTION
The maven android sdk deployer by default uses 'android' as the group id instead
of com.google.android.  I believe google with Gradle is starting to move toward
the com.google.android groupID but for legacy projects the 'android' groupID still
needs to be supported otherwise projects can't be configured.
