### PR TITLE
Added repository to archetype catalog

### DIFF
--- a/android-archetype-catalog.xml
+++ b/android-archetype-catalog.xml
@@ -4,17 +4,20 @@
     <archetype>
       <groupId>de.akquinet.android.archetypes</groupId>
       <artifactId>android-quickstart</artifactId>
-      <version>1.0.8</version>
+      <version>1.1.0</version>
+      <repository>http://repo1.maven.org/maven2</repository>
     </archetype>
     <archetype>
       <groupId>de.akquinet.android.archetypes</groupId>
       <artifactId>android-with-test</artifactId>
-      <version>1.0.8</version>
+      <version>1.1.0</version>
+      <repository>http://repo1.maven.org/maven2</repository>
     </archetype>
     <archetype>
       <groupId>de.akquinet.android.archetypes</groupId>
       <artifactId>android-release</artifactId>
-      <version>1.0.8</version>
+      <version>1.1.0</version>
+      <repository>http://repo1.maven.org/maven2</repository>
     </archetype>
   </archetypes>
 </archetype-catalog>


### PR DESCRIPTION
Creating a project from archetype via the New Project wizard failed
with error: The desired archetype does not exist.
This commit fixes the problem by adding repository url for each
archetype, so maven searches the central repository for them instead
of our repository.
The version numbers of the archetypes are also updated.

Related to #153.
