### PR TITLE
Fixed failing tests on Windows due to hardcoded paths

### DIFF
--- a/me.gladwell.eclipse.m2e.android.test/pom.xml
+++ b/me.gladwell.eclipse.m2e.android.test/pom.xml
@@ -74,8 +74,16 @@
                     me.gladwell.eclipse.m2e.android.test/target/plugin_customisation.ini
                 </outputFile>
                 <regex>false</regex>
-                <token>$ANDROID_HOME$</token>
-                <value>${env.ANDROID_HOME}</value>
+                <replacements>
+                    <replacement>
+                        <token>$ANDROID_HOME$</token>
+                        <value>${env.ANDROID_HOME}</value>
+                    </replacement>
+                    <replacement>
+                        <token>\</token>
+                        <value>\\</value>
+                    </replacement>
+                </replacements>
             </configuration>
         </plugin>
 		</plugins>

--- a/me.gladwell.eclipse.m2e.android.test/src/me/gladwell/eclipse/m2e/android/test/AndroidMavenPluginTestCase.java
+++ b/me.gladwell.eclipse.m2e.android.test/src/me/gladwell/eclipse/m2e/android/test/AndroidMavenPluginTestCase.java
@@ -8,6 +8,8 @@
 
 package me.gladwell.eclipse.m2e.android.test;
 
+import static java.io.File.separator;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -76,14 +78,14 @@ public abstract class AndroidMavenPluginTestCase extends AbstractMavenProjectTes
     }
 
     protected IProject importAndroidProject(String name) throws Exception {
-        IProject project = importProject("projects/" + name + "/pom.xml");
+        IProject project = importProject("projects" + separator + name + separator + "pom.xml");
         waitForJobsToComplete();
         waitForAdtToLoad();
         return project;
     }
 
     protected IProject importAndroidProject(String name, File folder) throws Exception {
-        IProject project = importProject("projects/" + name + "/pom.xml", folder);
+        IProject project = importProject("projects" + separator + name + separator + "pom.xml", folder);
         waitForJobsToComplete();
         waitForAdtToLoad();
         return project;

--- a/me.gladwell.eclipse.m2e.android.test/src/me/gladwell/eclipse/m2e/android/test/ApplicationAndroidMavenPluginTest.java
+++ b/me.gladwell.eclipse.m2e.android.test/src/me/gladwell/eclipse/m2e/android/test/ApplicationAndroidMavenPluginTest.java
@@ -136,12 +136,14 @@ public class ApplicationAndroidMavenPluginTest extends AndroidMavenPluginTestCas
     }
 
     public void testConfigureSetsCorrectSourceOutputFolder() throws Exception {
-        IClasspathEntry entry = findSourceEntry(javaProject.getRawClasspath(), "src/main/java");
+        IClasspathEntry entry = findSourceEntry(javaProject.getRawClasspath(), "src" + separator + "main" + separator
+                + "java");
         assertTrue(entry.getOutputLocation().toOSString().endsWith(ANDROID_CLASSES_FOLDER));
     }
 
     public void testConfigureSetsCorrectTestOutputFolder() throws Exception {
-        IClasspathEntry entry = findSourceEntry(javaProject.getRawClasspath(), "src/test/java");
+        IClasspathEntry entry = findSourceEntry(javaProject.getRawClasspath(), "src" + separator + "test" + separator
+                + "java");
         assertTrue(entry.getOutputLocation().toOSString().endsWith(ANDROID_TEST_CLASSES_FOLDER));
     }
 


### PR DESCRIPTION
Some tests failed on Windows becaused unix separators were hardcoded
in the file paths.
pom.xml is also modified for escaping Android SDK path on Windows.
