### PR TITLE
Enforce that specific android platform versions are installed

### DIFF
--- a/me.gladwell.eclipse.m2e.android.test/pom.xml
+++ b/me.gladwell.eclipse.m2e.android.test/pom.xml
@@ -35,6 +35,29 @@
   <build>
     <plugins>
       <plugin>
+      	<groupId>org.apache.maven.plugins</groupId>
+      	<artifactId>maven-enforcer-plugin</artifactId>
+      	<version>1.3.1</version>
+      	<executions>
+      		<execution>
+      			<id>enforce-android-versions-exist</id>
+      			<goals>
+      				<goal>enforce</goal>
+      			</goals>
+      			<configuration>
+      				<rules>
+      					<requireFilesExist>
+      						<files>
+      							<file>${env.ANDROID_HOME}/platforms/android-7</file>
+      							<file>${env.ANDROID_HOME}/platforms/android-10</file>
+      						</files>
+      					</requireFilesExist>
+      				</rules>
+      			</configuration>
+      		</execution>
+      	</executions>
+      </plugin>
+      <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-surefire-plugin</artifactId>
         <version>${tycho-version}</version>


### PR DESCRIPTION
This change uses the maven enforcer plugin to make sure the
necessary android platform versions are installed.  Otherwise
tests will fail due to the missing configurations.  Addresses
an issue in #236.
