### PR TITLE
Fix tycho test targetplatform

### DIFF
--- a/indigo/indigo.target
+++ b/indigo/indigo.target
@@ -23,6 +23,7 @@
          <repository location="http://download.eclipse.org/aether/aether-core/releases/"/>
       </location>
       <location includeAllPlatforms="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+         <unit id="org.eclipse.sdk.ide" version="0.0.0"/>
          <repository location="http://download.eclipse.org/releases/indigo/"/>
       </location>
       <location includeAllPlatforms="false" includeMode="planner" includeSource="true" type="InstallableUnit">

--- a/juno/juno.target
+++ b/juno/juno.target
@@ -24,6 +24,7 @@
       </location>
       <location includeAllPlatforms="false" includeMode="planner" includeSource="true" type="InstallableUnit">
          <repository location="http://download.eclipse.org/releases/juno/"/>
+         <unit id="org.eclipse.sdk.ide" version="0.0.0"/>
       </location>
    </locations>
    <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.6"/>

--- a/kepler/kepler.target
+++ b/kepler/kepler.target
@@ -20,6 +20,7 @@
       </location>
       <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
          <repository location="http://download.eclipse.org/releases/kepler/"/>
+         <unit id="org.eclipse.sdk.ide" version="0.0.0"/>
       </location>
    </locations>
    <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5"/>

--- a/luna/luna.target
+++ b/luna/luna.target
@@ -24,6 +24,7 @@
       </location>
       <location includeAllPlatforms="false" includeMode="planner" includeSource="true" type="InstallableUnit">
          <repository location="http://download.eclipse.org/releases/luna/"/>
+         <unit id="org.eclipse.sdk.ide" version="0.0.0"/>
       </location>
    </locations>
    <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.6"/>

--- a/me.gladwell.eclipse.m2e.android.test/pom.xml
+++ b/me.gladwell.eclipse.m2e.android.test/pom.xml
@@ -35,27 +35,28 @@
   <build>
     <plugins>
       <plugin>
-      	<groupId>org.apache.maven.plugins</groupId>
-      	<artifactId>maven-enforcer-plugin</artifactId>
-      	<version>1.3.1</version>
-      	<executions>
-      		<execution>
-      			<id>enforce-android-versions-exist</id>
-      			<goals>
-      				<goal>enforce</goal>
-      			</goals>
-      			<configuration>
-      				<rules>
-      					<requireFilesExist>
-      						<files>
-      							<file>${env.ANDROID_HOME}/platforms/android-7</file>
-      							<file>${env.ANDROID_HOME}/platforms/android-10</file>
-      						</files>
-      					</requireFilesExist>
-      				</rules>
-      			</configuration>
-      		</execution>
-      	</executions>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>1.3.1</version>
+        <executions>
+          <execution>
+            <id>enforce-android-versions-exist</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireFilesExist>
+                  <files>
+                    <file>${env.ANDROID_HOME}/platforms/android-7</file>
+                    <file>${env.ANDROID_HOME}/platforms/android-10</file>
+                  </files>
+                </requireFilesExist>
+              </rules>
+              <fail>false</fail>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
@@ -81,6 +82,11 @@
             <dependency>
               <type>p2-installable-unit</type>
               <artifactId>com.android.ide.eclipse.traceview</artifactId>
+            </dependency>
+            <dependency>
+              <type>p2-installable-unit</type>
+              <artifactId>org.eclipse.sdk.ide</artifactId>
+              <version>0.0.0</version>
             </dependency>
           </dependencies>
         </configuration>


### PR DESCRIPTION
Fixes and issue with tycho not configuring the test platform correctly when launching the tests.  Now instead of 55 tests failing, only the 9 tests that require Android 10 and Android 7 will fail if those items aren't available.  The Enforcer plugin is still in place, but has been changed to not fail if the targets aren't included.  It is there for an added safety check and can be enabled if necessary.
