### PR TITLE
Ensure source folders appear first in the classpath list.

### DIFF
--- a/me.gladwell.eclipse.m2e.android.test/src/me/gladwell/eclipse/m2e/android/test/ApplicationAndroidMavenPluginTest.java
+++ b/me.gladwell.eclipse.m2e.android.test/src/me/gladwell/eclipse/m2e/android/test/ApplicationAndroidMavenPluginTest.java
@@ -281,4 +281,10 @@ public class ApplicationAndroidMavenPluginTest extends AndroidMavenPluginTestCas
         IClasspathEntry gen = findSourceEntry(javaProject.getRawClasspath(), "gen");
         assertFalse("external assets folder isn't linked", booleanAttribute(IGNORE_OPTIONAL_PROBLEMS, gen));
     }
+    
+    public void testSourceFolderOrder() throws Exception {
+    	IClasspathEntry[] entries = javaProject.getRawClasspath();
+    	assertTrue(entries[0].getPath().toString().contains("src/main/java"));
+       	assertTrue(entries[1].getPath().toString().contains("src/test/java"));
+    }
 }

--- a/me.gladwell.eclipse.m2e.android.test/src/me/gladwell/eclipse/m2e/android/test/LegacyAndroidMavenPluginTest.java
+++ b/me.gladwell.eclipse.m2e.android.test/src/me/gladwell/eclipse/m2e/android/test/LegacyAndroidMavenPluginTest.java
@@ -9,6 +9,10 @@
 package me.gladwell.eclipse.m2e.android.test;
 
 import org.eclipse.core.resources.IProject;
+import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.internal.core.JavaProject;
 
 @SuppressWarnings("restriction")
 public class LegacyAndroidMavenPluginTest extends AndroidMavenPluginTestCase {
@@ -25,6 +29,12 @@ public class LegacyAndroidMavenPluginTest extends AndroidMavenPluginTestCase {
 
     public void testConfigure() throws Exception {
         assertNoErrors(project);
+    }
+    
+    public void testSourceMainJavaFirstEntry() throws Exception {
+    	IJavaProject p = JavaCore.create(project);
+    	IClasspathEntry[] entries = p.readRawClasspath();
+    	assertTrue(entries[0].getPath().toString().contains("src/main/java"));
     }
 
 }

--- a/me.gladwell.eclipse.m2e.android/META-INF/MANIFEST.MF
+++ b/me.gladwell.eclipse.m2e.android/META-INF/MANIFEST.MF
@@ -21,5 +21,6 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.jdt.junit.core
 Bundle-RequiredExecutionEnvironment: J2SE-1.5
 Bundle-ActivationPolicy: lazy
-Export-Package: me.gladwell.eclipse.m2e.android,me.gladwell.eclipse.m2
- e.android.configuration
+Export-Package: me.gladwell.eclipse.m2e.android,
+ me.gladwell.eclipse.m2e.android.configuration,
+ me.gladwell.eclipse.m2e.android.configuration.classpath

--- a/me.gladwell.eclipse.m2e.android/src/main/java/me/gladwell/eclipse/m2e/android/configuration/classpath/ClasspathModule.java
+++ b/me.gladwell.eclipse.m2e.android/src/main/java/me/gladwell/eclipse/m2e/android/configuration/classpath/ClasspathModule.java
@@ -24,6 +24,8 @@ public class ClasspathModule extends AbstractModule {
         rawClasspathConfigurers.add(persistConfigurer);
         rawClasspathConfigurers.add(new RemoveNonRuntimeDependenciesConfigurer());
         rawClasspathConfigurers.add(removeProjectsConfigurer);
+        // The ReorderClasspathConfigurer needs to come last in the sequence
+        rawClasspathConfigurers.add(new ReorderClasspathConfigurer());
 
         return Collections.unmodifiableList(rawClasspathConfigurers);
     }

--- a/me.gladwell.eclipse.m2e.android/src/main/java/me/gladwell/eclipse/m2e/android/configuration/classpath/ReorderClasspathConfigurer.java
+++ b/me.gladwell.eclipse.m2e.android/src/main/java/me/gladwell/eclipse/m2e/android/configuration/classpath/ReorderClasspathConfigurer.java
@@ -29,7 +29,6 @@ import me.gladwell.eclipse.m2e.android.project.MavenAndroidProject;
 @SuppressWarnings("restriction")
 public class ReorderClasspathConfigurer implements RawClasspathConfigurer {
 
-	
 	private MavenAndroidProject mavenAndroidProject;
 	protected IClasspathEntry[] originalClasspathEntries;
 	protected ArrayList<IClasspathEntry> arrayEntries;
@@ -40,12 +39,12 @@ public class ReorderClasspathConfigurer implements RawClasspathConfigurer {
 
 	public void configure(MavenAndroidProject mavenAndroidProject, EclipseAndroidProject eclipseProject,
 			IClasspathDescriptor classpath) {
-		
-		this.mavenAndroidProject = mavenAndroidProject; 
+
+		this.mavenAndroidProject = mavenAndroidProject;
 		arrayEntries = new ArrayList<IClasspathEntry>();
-		
+
 		IJavaProject javaproject = JavaCore.create(eclipseProject.getProject());
-		
+
 		originalClasspathEntries = javaproject.readRawClasspath();
 
 		reorderClasspathEntries();
@@ -77,52 +76,52 @@ public class ReorderClasspathConfigurer implements RawClasspathConfigurer {
 		addNonRuntimeContainer();
 		addTheRest();
 	}
-	
+
 	protected void addMavenSourceFolder() {
-		
+
 		List<String> sourceRoots = mavenAndroidProject.getSourcePaths();
-		
+
 		for (String sourceRoot : sourceRoots) {
 			IClasspathEntry newEntry = findClasspathEntry(sourceRoot);
 			addEntry(newEntry);
-		}		
+		}
 	}
 
 	protected void addMavenResourceFolder() {
-		
+
 		List<Resource> resources = mavenAndroidProject.getResources();
-		
+
 		for (Resource res : resources) {
 			String directory = res.getDirectory();
 			IClasspathEntry newEntry = findClasspathEntry(directory);
 			addEntry(newEntry);
-		}		
+		}
 	}
 
 	protected void addMavenTestSourceFolder() {
 		List<String> sourceRoots = mavenAndroidProject.getTestSourcePaths();
-		
+
 		for (String sourceRoot : sourceRoots) {
 			IClasspathEntry newEntry = findClasspathEntry(sourceRoot);
 			addEntry(newEntry);
-		}		
+		}
 	}
 
 	protected void addMavenTestResourceFolder() {
 		List<Resource> resources = mavenAndroidProject.getTestResources();
-		
+
 		for (Resource res : resources) {
 			String directory = res.getDirectory();
 			IClasspathEntry newEntry = findClasspathEntry(directory);
 			addEntry(newEntry);
-		}		
+		}
 	}
-	
+
 	protected void addAndroidFrameworkContainer() {
 		IClasspathEntry entry = findClasspathEntry(AdtConstants.CONTAINER_FRAMEWORK);
 		addEntry(entry);
 	}
-	
+
 	protected void addAndroidPrivateLibrariesContainer() {
 		IClasspathEntry entry = findClasspathEntry(AdtConstants.CONTAINER_PRIVATE_LIBRARIES);
 		addEntry(entry);
@@ -132,44 +131,40 @@ public class ReorderClasspathConfigurer implements RawClasspathConfigurer {
 		IClasspathEntry entry = findClasspathEntry(AdtConstants.CONTAINER_DEPENDENCIES);
 		addEntry(entry);
 	}
-	
+
 	protected void addMavenDependenciesContainer() {
 		IClasspathEntry entry = findClasspathEntry(IClasspathManager.CONTAINER_ID);
-		addEntry(entry);		
+		addEntry(entry);
 	}
-	
+
 	protected void addNonRuntimeContainer() {
 		IClasspathEntry entry = findClasspathEntry(AndroidMavenPlugin.CONTAINER_NONRUNTIME_DEPENDENCIES);
-		addEntry(entry);		
+		addEntry(entry);
 	}
-	
+
 	protected void addTheRest() {
 		for (IClasspathEntry classpathEntry : originalClasspathEntries) {
-			if (!hasSourceFolder(classpathEntry)
-					&& !hasResource(classpathEntry)
-					&& !hasTestSourceFolder(classpathEntry)
-					&& !hasTestResource(classpathEntry)
-					&& !hasAndroidFramework(classpathEntry)
-					&& !hasMavenDependencies(classpathEntry)
-					&& !hasAndroidLibraries(classpathEntry)
-					&& !hasAndroidDependencies(classpathEntry)
+			if (!hasSourceFolder(classpathEntry) && !hasResource(classpathEntry)
+					&& !hasTestSourceFolder(classpathEntry) && !hasTestResource(classpathEntry)
+					&& !hasAndroidFramework(classpathEntry) && !hasMavenDependencies(classpathEntry)
+					&& !hasAndroidLibraries(classpathEntry) && !hasAndroidDependencies(classpathEntry)
 					&& !hasNonRuntimeDependencies(classpathEntry)) {
 				addEntry(classpathEntry);
 			}
 		}
 	}
-	
+
 	protected boolean hasSourceFolder(IClasspathEntry entry) {
 		List<String> sourceRoots = mavenAndroidProject.getSourcePaths();
-		
+
 		for (String sourceRoot : sourceRoots) {
-			if (sourceRoot.contains(entry.getPath().toString())) {
+			if (sourceRoot.contains(entry.getPath().toOSString())) {
 				return true;
 			}
 		}
 		return false;
 	}
-	
+
 	protected boolean hasAndroidFramework(IClasspathEntry entry) {
 		String path = entry.getPath().toString();
 		for (IClasspathEntry arrayEntry : arrayEntries) {
@@ -179,7 +174,7 @@ public class ReorderClasspathConfigurer implements RawClasspathConfigurer {
 		}
 		return false;
 	}
-	
+
 	protected boolean hasMavenDependencies(IClasspathEntry entry) {
 		String path = entry.getPath().toString();
 		for (IClasspathEntry arrayEntry : arrayEntries) {
@@ -199,7 +194,7 @@ public class ReorderClasspathConfigurer implements RawClasspathConfigurer {
 		}
 		return false;
 	}
-	
+
 	protected boolean hasAndroidLibraries(IClasspathEntry entry) {
 		String path = entry.getPath().toString();
 		for (IClasspathEntry arrayEntry : arrayEntries) {
@@ -219,22 +214,22 @@ public class ReorderClasspathConfigurer implements RawClasspathConfigurer {
 		}
 		return false;
 	}
-	
+
 	protected boolean hasTestSourceFolder(IClasspathEntry entry) {
 		List<String> sourceRoots = mavenAndroidProject.getTestSourcePaths();
-		
+
 		for (String sourceRoot : sourceRoots) {
-			if (sourceRoot.contains(entry.getPath().toString())) {
+			if (sourceRoot.contains(entry.getPath().toOSString())) {
 				return true;
 			}
-		}		
-		return false;		
+		}
+		return false;
 	}
-	
+
 	protected boolean hasResource(IClasspathEntry entry) {
 		List<Resource> resources = mavenAndroidProject.getResources();
 		for (Resource resource : resources) {
-			if (resource.getDirectory().contains(entry.getPath().toString())) {
+			if (resource.getDirectory().contains(entry.getPath().toOSString())) {
 				return true;
 			}
 		}
@@ -244,13 +239,13 @@ public class ReorderClasspathConfigurer implements RawClasspathConfigurer {
 	protected boolean hasTestResource(IClasspathEntry entry) {
 		List<Resource> resources = mavenAndroidProject.getTestResources();
 		for (Resource resource : resources) {
-			if (resource.getDirectory().contains(entry.getPath().toString())) {
+			if (resource.getDirectory().contains(entry.getPath().toOSString())) {
 				return true;
 			}
 		}
 		return false;
 	}
-	
+
 	protected void addEntry(IClasspathEntry entry) {
 		if (entry != null) {
 			arrayEntries.add(entry);
@@ -259,13 +254,12 @@ public class ReorderClasspathConfigurer implements RawClasspathConfigurer {
 
 	private IClasspathEntry findClasspathEntry(String substring) {
 		for (IClasspathEntry classpathEntry : originalClasspathEntries) {
-			String path = classpathEntry.getPath().toString();
+			String path = classpathEntry.getPath().toOSString();
 			if (substring.contains(path)) {
 				return classpathEntry;
 			}
 		}
 		return null;
 	}
-
 
 }

--- a/me.gladwell.eclipse.m2e.android/src/main/java/me/gladwell/eclipse/m2e/android/configuration/classpath/ReorderClasspathConfigurer.java
+++ b/me.gladwell.eclipse.m2e.android/src/main/java/me/gladwell/eclipse/m2e/android/configuration/classpath/ReorderClasspathConfigurer.java
@@ -1,0 +1,271 @@
+/*******************************************************************************
+ * Copyright (c) 2014 David Carver
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+
+package me.gladwell.eclipse.m2e.android.configuration.classpath;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.maven.model.Resource;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.m2e.jdt.IClasspathDescriptor;
+import org.eclipse.m2e.jdt.IClasspathManager;
+
+import com.android.ide.eclipse.adt.AdtConstants;
+
+import me.gladwell.eclipse.m2e.android.AndroidMavenPlugin;
+import me.gladwell.eclipse.m2e.android.Log;
+import me.gladwell.eclipse.m2e.android.project.EclipseAndroidProject;
+import me.gladwell.eclipse.m2e.android.project.MavenAndroidProject;
+
+@SuppressWarnings("restriction")
+public class ReorderClasspathConfigurer implements RawClasspathConfigurer {
+
+	
+	private MavenAndroidProject mavenAndroidProject;
+	protected IClasspathEntry[] originalClasspathEntries;
+	protected ArrayList<IClasspathEntry> arrayEntries;
+
+	public boolean shouldApplyTo(MavenAndroidProject project) {
+		return true;
+	}
+
+	public void configure(MavenAndroidProject mavenAndroidProject, EclipseAndroidProject eclipseProject,
+			IClasspathDescriptor classpath) {
+		
+		this.mavenAndroidProject = mavenAndroidProject; 
+		arrayEntries = new ArrayList<IClasspathEntry>();
+		
+		IJavaProject javaproject = JavaCore.create(eclipseProject.getProject());
+		
+		originalClasspathEntries = javaproject.readRawClasspath();
+
+		reorderClasspathEntries();
+
+		rewriteClasspathFile(javaproject);
+	}
+
+	private void rewriteClasspathFile(IJavaProject javaproject) {
+		IClasspathEntry[] newEntries = new IClasspathEntry[arrayEntries.size()];
+		arrayEntries.toArray(newEntries);
+
+		try {
+			javaproject.setRawClasspath(newEntries, new NullProgressMonitor());
+			javaproject.save(new NullProgressMonitor(), false);
+		} catch (Exception ex) {
+			Log.warn(ex.getMessage());
+		}
+	}
+
+	private void reorderClasspathEntries() {
+		addMavenSourceFolder();
+		addMavenResourceFolder();
+		addMavenTestSourceFolder();
+		addMavenTestResourceFolder();
+		addAndroidFrameworkContainer();
+		addAndroidPrivateLibrariesContainer();
+		addAndroidDependenciesContainer();
+		addMavenDependenciesContainer();
+		addNonRuntimeContainer();
+		addTheRest();
+	}
+	
+	protected void addMavenSourceFolder() {
+		
+		List<String> sourceRoots = mavenAndroidProject.getSourcePaths();
+		
+		for (String sourceRoot : sourceRoots) {
+			IClasspathEntry newEntry = findClasspathEntry(sourceRoot);
+			addEntry(newEntry);
+		}		
+	}
+
+	protected void addMavenResourceFolder() {
+		
+		List<Resource> resources = mavenAndroidProject.getResources();
+		
+		for (Resource res : resources) {
+			String directory = res.getDirectory();
+			IClasspathEntry newEntry = findClasspathEntry(directory);
+			addEntry(newEntry);
+		}		
+	}
+
+	protected void addMavenTestSourceFolder() {
+		List<String> sourceRoots = mavenAndroidProject.getTestSourcePaths();
+		
+		for (String sourceRoot : sourceRoots) {
+			IClasspathEntry newEntry = findClasspathEntry(sourceRoot);
+			addEntry(newEntry);
+		}		
+	}
+
+	protected void addMavenTestResourceFolder() {
+		List<Resource> resources = mavenAndroidProject.getTestResources();
+		
+		for (Resource res : resources) {
+			String directory = res.getDirectory();
+			IClasspathEntry newEntry = findClasspathEntry(directory);
+			addEntry(newEntry);
+		}		
+	}
+	
+	protected void addAndroidFrameworkContainer() {
+		IClasspathEntry entry = findClasspathEntry(AdtConstants.CONTAINER_FRAMEWORK);
+		addEntry(entry);
+	}
+	
+	protected void addAndroidPrivateLibrariesContainer() {
+		IClasspathEntry entry = findClasspathEntry(AdtConstants.CONTAINER_PRIVATE_LIBRARIES);
+		addEntry(entry);
+	}
+
+	protected void addAndroidDependenciesContainer() {
+		IClasspathEntry entry = findClasspathEntry(AdtConstants.CONTAINER_DEPENDENCIES);
+		addEntry(entry);
+	}
+	
+	protected void addMavenDependenciesContainer() {
+		IClasspathEntry entry = findClasspathEntry(IClasspathManager.CONTAINER_ID);
+		addEntry(entry);		
+	}
+	
+	protected void addNonRuntimeContainer() {
+		IClasspathEntry entry = findClasspathEntry(AndroidMavenPlugin.CONTAINER_NONRUNTIME_DEPENDENCIES);
+		addEntry(entry);		
+	}
+	
+	protected void addTheRest() {
+		for (IClasspathEntry classpathEntry : originalClasspathEntries) {
+			if (!hasSourceFolder(classpathEntry)
+					&& !hasResource(classpathEntry)
+					&& !hasTestSourceFolder(classpathEntry)
+					&& !hasTestResource(classpathEntry)
+					&& !hasAndroidFramework(classpathEntry)
+					&& !hasMavenDependencies(classpathEntry)
+					&& !hasAndroidLibraries(classpathEntry)
+					&& !hasAndroidDependencies(classpathEntry)
+					&& !hasNonRuntimeDependencies(classpathEntry)) {
+				addEntry(classpathEntry);
+			}
+		}
+	}
+	
+	protected boolean hasSourceFolder(IClasspathEntry entry) {
+		List<String> sourceRoots = mavenAndroidProject.getSourcePaths();
+		
+		for (String sourceRoot : sourceRoots) {
+			if (sourceRoot.contains(entry.getPath().toString())) {
+				return true;
+			}
+		}
+		return false;
+	}
+	
+	protected boolean hasAndroidFramework(IClasspathEntry entry) {
+		String path = entry.getPath().toString();
+		for (IClasspathEntry arrayEntry : arrayEntries) {
+			if (path.equals(AdtConstants.CONTAINER_FRAMEWORK) && arrayEntry.equals(entry)) {
+				return true;
+			}
+		}
+		return false;
+	}
+	
+	protected boolean hasMavenDependencies(IClasspathEntry entry) {
+		String path = entry.getPath().toString();
+		for (IClasspathEntry arrayEntry : arrayEntries) {
+			if (path.equals(IClasspathManager.CONTAINER_ID) && arrayEntry.equals(entry)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	protected boolean hasNonRuntimeDependencies(IClasspathEntry entry) {
+		String path = entry.getPath().toString();
+		for (IClasspathEntry arrayEntry : arrayEntries) {
+			if (path.equals(AndroidMavenPlugin.CONTAINER_NONRUNTIME_DEPENDENCIES) && arrayEntry.equals(entry)) {
+				return true;
+			}
+		}
+		return false;
+	}
+	
+	protected boolean hasAndroidLibraries(IClasspathEntry entry) {
+		String path = entry.getPath().toString();
+		for (IClasspathEntry arrayEntry : arrayEntries) {
+			if (path.equals(AdtConstants.CONTAINER_PRIVATE_LIBRARIES) && arrayEntry.equals(entry)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	protected boolean hasAndroidDependencies(IClasspathEntry entry) {
+		String path = entry.getPath().toString();
+		for (IClasspathEntry arrayEntry : arrayEntries) {
+			if (path.equals(AdtConstants.CONTAINER_DEPENDENCIES) && arrayEntry.equals(entry)) {
+				return true;
+			}
+		}
+		return false;
+	}
+	
+	protected boolean hasTestSourceFolder(IClasspathEntry entry) {
+		List<String> sourceRoots = mavenAndroidProject.getTestSourcePaths();
+		
+		for (String sourceRoot : sourceRoots) {
+			if (sourceRoot.contains(entry.getPath().toString())) {
+				return true;
+			}
+		}		
+		return false;		
+	}
+	
+	protected boolean hasResource(IClasspathEntry entry) {
+		List<Resource> resources = mavenAndroidProject.getResources();
+		for (Resource resource : resources) {
+			if (resource.getDirectory().contains(entry.getPath().toString())) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	protected boolean hasTestResource(IClasspathEntry entry) {
+		List<Resource> resources = mavenAndroidProject.getTestResources();
+		for (Resource resource : resources) {
+			if (resource.getDirectory().contains(entry.getPath().toString())) {
+				return true;
+			}
+		}
+		return false;
+	}
+	
+	protected void addEntry(IClasspathEntry entry) {
+		if (entry != null) {
+			arrayEntries.add(entry);
+		}
+	}
+
+	private IClasspathEntry findClasspathEntry(String substring) {
+		for (IClasspathEntry classpathEntry : originalClasspathEntries) {
+			String path = classpathEntry.getPath().toString();
+			if (substring.contains(path)) {
+				return classpathEntry;
+			}
+		}
+		return null;
+	}
+
+
+}

--- a/me.gladwell.eclipse.m2e.android/src/main/java/me/gladwell/eclipse/m2e/android/project/JaywayMavenAndroidProject.java
+++ b/me.gladwell.eclipse.m2e.android/src/main/java/me/gladwell/eclipse/m2e/android/project/JaywayMavenAndroidProject.java
@@ -1,9 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2013, 2014 Ricardo Gladwell and David Carver
+ * Copyright (c) 2012, 2013, 2014 Ricardo Gladwell and others
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * 2014-09-10 - David Carver - added helper methods to get test/source/resources
  *******************************************************************************/
 
 package me.gladwell.eclipse.m2e.android.project;
@@ -17,6 +19,7 @@ import me.gladwell.eclipse.m2e.android.resolve.LibraryResolver;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.model.Plugin;
+import org.apache.maven.model.Resource;
 import org.apache.maven.project.MavenProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
@@ -144,6 +147,18 @@ public class JaywayMavenAndroidProject implements MavenAndroidProject {
 
     public List<String> getSourcePaths() {
         return mavenProject.getCompileSourceRoots();
+    }
+    
+    public List<String> getTestSourcePaths() {
+    	return mavenProject.getTestCompileSourceRoots();
+    }
+    
+    public List<Resource> getResources() {
+    	return mavenProject.getResources();
+    }
+    
+    public List<Resource> getTestResources() {
+    	return mavenProject.getTestResources();
     }
 
 }

--- a/me.gladwell.eclipse.m2e.android/src/main/java/me/gladwell/eclipse/m2e/android/project/MavenAndroidProject.java
+++ b/me.gladwell.eclipse.m2e.android/src/main/java/me/gladwell/eclipse/m2e/android/project/MavenAndroidProject.java
@@ -1,15 +1,19 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2013, 2014 Ricardo Gladwell
+ * Copyright (c) 2012 - 2014 Ricardo Gladwell and others
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * 2014-09-10 - David Carver - added helper methods to get test/source/resources
  *******************************************************************************/
 
 package me.gladwell.eclipse.m2e.android.project;
 
 import java.io.File;
 import java.util.List;
+
+import org.apache.maven.model.Resource;
 
 public interface MavenAndroidProject {
 
@@ -38,5 +42,12 @@ public interface MavenAndroidProject {
     public List<String> getSourcePaths();
 
     public boolean isIgnoreOptionalWarningsInGenFolder();
+    
+    public List<Resource> getResources();
+    
+    public List<String> getTestSourcePaths();
+    
+    public List<Resource> getTestResources();
+    
     
 }


### PR DESCRIPTION
After running the other Classpath Configuration classes the source folders
are out of sequence, causing all sorts of problems looking up source. This
is an attempt to re-order the classpaths.  It hasn't yet been tied into the
code, but here for code review and comment.