### PR TITLE
Updated ADT dependency in target definitions

### DIFF
--- a/indigo/indigo.target
+++ b/indigo/indigo.target
@@ -3,10 +3,10 @@
 <target name="eclipse 3.7.0" sequenceNumber="13">
    <locations>
       <location includeAllPlatforms="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-         <unit id="com.android.ide.eclipse.adt.feature.feature.group" version="23.0.2.1259578"/>
-         <unit id="com.android.ide.eclipse.ddms.feature.feature.group" version="23.0.2.1259578"/>
-         <unit id="com.android.ide.eclipse.hierarchyviewer.feature.feature.group" version="23.0.2.1259578"/>
-         <unit id="com.android.ide.eclipse.traceview.feature.feature.group" version="23.0.2.1259578"/>
+         <unit id="com.android.ide.eclipse.adt.feature.feature.group" version="23.0.3.1327240"/>
+         <unit id="com.android.ide.eclipse.ddms.feature.feature.group" version="23.0.3.1327240"/>
+         <unit id="com.android.ide.eclipse.hierarchyviewer.feature.feature.group" version="23.0.3.1327240"/>
+         <unit id="com.android.ide.eclipse.traceview.feature.feature.group" version="23.0.3.1327240"/>
          <repository location="https://dl-ssl.google.com/android/eclipse/"/>
       </location>
       <location includeAllPlatforms="false" includeMode="planner" includeSource="true" type="InstallableUnit">

--- a/juno/juno.target
+++ b/juno/juno.target
@@ -3,10 +3,10 @@
 <target name="eclipse 3.7.0" sequenceNumber="13">
    <locations>
       <location includeAllPlatforms="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-         <unit id="com.android.ide.eclipse.adt.feature.feature.group" version="23.0.2.1259578"/>
-         <unit id="com.android.ide.eclipse.ddms.feature.feature.group" version="23.0.2.1259578"/>
-         <unit id="com.android.ide.eclipse.hierarchyviewer.feature.feature.group" version="23.0.2.1259578"/>
-         <unit id="com.android.ide.eclipse.traceview.feature.feature.group" version="23.0.2.1259578"/>
+         <unit id="com.android.ide.eclipse.adt.feature.feature.group" version="23.0.3.1327240"/>
+         <unit id="com.android.ide.eclipse.ddms.feature.feature.group" version="23.0.3.1327240"/>
+         <unit id="com.android.ide.eclipse.hierarchyviewer.feature.feature.group" version="23.0.3.1327240"/>
+         <unit id="com.android.ide.eclipse.traceview.feature.feature.group" version="23.0.3.1327240"/>
          <repository location="https://dl-ssl.google.com/android/eclipse/"/>
       </location>
       <location includeAllPlatforms="false" includeMode="planner" includeSource="true" type="InstallableUnit">

--- a/kepler/kepler.target
+++ b/kepler/kepler.target
@@ -3,10 +3,10 @@
 <target name="Eclipse Kepler 4.3.0">
    <locations>
       <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-         <unit id="com.android.ide.eclipse.adt.feature.feature.group" version="23.0.2.1259578"/>
-         <unit id="com.android.ide.eclipse.ddms.feature.feature.group" version="23.0.2.1259578"/>
-         <unit id="com.android.ide.eclipse.hierarchyviewer.feature.feature.group" version="23.0.2.1259578"/>
-         <unit id="com.android.ide.eclipse.traceview.feature.feature.group" version="23.0.2.1259578"/>
+         <unit id="com.android.ide.eclipse.adt.feature.feature.group" version="23.0.3.1327240"/>
+         <unit id="com.android.ide.eclipse.ddms.feature.feature.group" version="23.0.3.1327240"/>
+         <unit id="com.android.ide.eclipse.hierarchyviewer.feature.feature.group" version="23.0.3.1327240"/>
+         <unit id="com.android.ide.eclipse.traceview.feature.feature.group" version="23.0.3.1327240"/>
          <repository location="https://dl-ssl.google.com/android/eclipse/"/>
       </location>
       <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">

--- a/luna/luna.target
+++ b/luna/luna.target
@@ -3,10 +3,10 @@
 <target name="Eclipse 4.4.x (Luna)" sequenceNumber="43">
    <locations>
       <location includeAllPlatforms="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-         <unit id="com.android.ide.eclipse.adt.feature.feature.group" version="23.0.2.1259578"/>
-         <unit id="com.android.ide.eclipse.ddms.feature.feature.group" version="23.0.2.1259578"/>
-         <unit id="com.android.ide.eclipse.hierarchyviewer.feature.feature.group" version="23.0.2.1259578"/>
-         <unit id="com.android.ide.eclipse.traceview.feature.feature.group" version="23.0.2.1259578"/>
+         <unit id="com.android.ide.eclipse.adt.feature.feature.group" version="23.0.3.1327240"/>
+         <unit id="com.android.ide.eclipse.ddms.feature.feature.group" version="23.0.3.1327240"/>
+         <unit id="com.android.ide.eclipse.hierarchyviewer.feature.feature.group" version="23.0.3.1327240"/>
+         <unit id="com.android.ide.eclipse.traceview.feature.feature.group" version="23.0.3.1327240"/>
          <repository location="https://dl-ssl.google.com/android/eclipse/"/>
       </location>
       <location includeAllPlatforms="false" includeMode="planner" includeSource="true" type="InstallableUnit">


### PR DESCRIPTION
It seems the currently used version in the Google repo is not available anymore. I updated the version to the latest. I am not sure whether we could use some dynamic version resolution. I know it is possible to define `0.0.0` to always use the latest available unit, but it is not acceptable because we cannot know what changes occured to a newer version.
