### PR TITLE
Reenable testBuildDirectoryContainsCompiledClasses unit test

### DIFF
--- a/me.gladwell.eclipse.m2e.android.test/src/me/gladwell/eclipse/m2e/android/test/ApplicationAndroidMavenPluginTest.java
+++ b/me.gladwell.eclipse.m2e.android.test/src/me/gladwell/eclipse/m2e/android/test/ApplicationAndroidMavenPluginTest.java
@@ -125,14 +125,14 @@ public class ApplicationAndroidMavenPluginTest extends AndroidMavenPluginTestCas
     }
 
     // TODO quarantined intermittently failing integration test
-    public void ignoreTestBuildDirectoryContainsCompiledClasses() throws Exception {
+    public void testBuildDirectoryContainsCompiledClasses() throws Exception {
         File outputLocation = new File(ResourcesPlugin.getWorkspace().getRoot().getRawLocation().toOSString(),
                 javaProject.getPath().toOSString());
-        File apiDemosApplication = new File(outputLocation, "bin/classes/your/company/HelloAndroidActivity.class");
+        File compiledClass = new File(outputLocation, "bin/classes/your/company/HelloAndroidActivity.class");
 
         buildAndroidProject(project, IncrementalProjectBuilder.FULL_BUILD);
 
-        assertTrue(apiDemosApplication.exists());
+        assertTrue(compiledClass.exists());
     }
 
     public void testConfigureMarksMavenContainerExported() throws Exception {


### PR DESCRIPTION
This unit test was disabled because it actually did not build the project. Since 015ecfd projects can be built successfully, so this test now passes.
