### PR TITLE
Update Orbit Repository to latest version

### DIFF
--- a/indigo/indigo.target
+++ b/indigo/indigo.target
@@ -9,9 +9,14 @@
          <unit id="com.android.ide.eclipse.traceview.feature.feature.group" version="23.0.3.1327240"/>
          <repository location="https://dl-ssl.google.com/android/eclipse/"/>
       </location>
-      <location includeAllPlatforms="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-         <unit id="org.junit" version="4.8.2.v4_8_2_v20110321-1705"/>
-         <repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20110523182458/repository/"/>
+      <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+         <unit id="org.junit" version="4.11.0.v201303080030"/>
+         <unit id="org.hamcrest" version="1.1.0.v20090501071000"/>
+         <unit id="org.hamcrest.library" version="1.1.0.v20090501071000"/>
+         <unit id="org.mockito" version="1.8.4.v201303031500"/>
+         <unit id="org.hamcrest.integration" version="1.1.0.v201303031500"/>
+         <unit id="org.hamcrest.generator" version="1.1.0.v20090501071000"/>
+         <repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20130517111416/repository/"/>
       </location>
       <location includeAllPlatforms="false" includeMode="planner" includeSource="true" type="InstallableUnit">
          <unit id="org.eclipse.m2e.feature.feature.group" version="1.4.0.20130601-0317"/>

--- a/juno/juno.target
+++ b/juno/juno.target
@@ -9,9 +9,14 @@
          <unit id="com.android.ide.eclipse.traceview.feature.feature.group" version="23.0.3.1327240"/>
          <repository location="https://dl-ssl.google.com/android/eclipse/"/>
       </location>
-      <location includeAllPlatforms="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-         <unit id="org.junit" version="4.8.2.v4_8_2_v20110321-1705"/>
-         <repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20110523182458/repository/"/>
+      <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+         <unit id="org.junit" version="4.11.0.v201303080030"/>
+         <unit id="org.hamcrest" version="1.1.0.v20090501071000"/>
+         <unit id="org.hamcrest.library" version="1.1.0.v20090501071000"/>
+         <unit id="org.mockito" version="1.8.4.v201303031500"/>
+         <unit id="org.hamcrest.integration" version="1.1.0.v201303031500"/>
+         <unit id="org.hamcrest.generator" version="1.1.0.v20090501071000"/>
+         <repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20130517111416/repository/"/>
       </location>
       <location includeAllPlatforms="false" includeMode="planner" includeSource="true" type="InstallableUnit">
          <unit id="org.eclipse.m2e.feature.feature.group" version="1.4.0.20130601-0317"/>

--- a/kepler/kepler.target
+++ b/kepler/kepler.target
@@ -10,6 +10,15 @@
          <repository location="https://dl-ssl.google.com/android/eclipse/"/>
       </location>
       <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+         <unit id="org.junit" version="4.11.0.v201303080030"/>
+         <unit id="org.hamcrest" version="1.1.0.v20090501071000"/>
+         <unit id="org.hamcrest.library" version="1.1.0.v20090501071000"/>
+         <unit id="org.mockito" version="1.8.4.v201303031500"/>
+         <unit id="org.hamcrest.integration" version="1.1.0.v201303031500"/>
+         <unit id="org.hamcrest.generator" version="1.1.0.v20090501071000"/>
+         <repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20130517111416/repository/"/>
+      </location>
+      <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
          <unit id="org.eclipse.m2e.feature.feature.group" version="1.4.0.20130601-0317"/>
          <unit id="org.eclipse.m2e.sdk.feature.feature.group" version="1.4.0.20130601-0317"/>
          <repository location="http://download.eclipse.org/technology/m2e/releases/1.4/1.4.0.20130601-0317"/>

--- a/luna/luna.target
+++ b/luna/luna.target
@@ -1,31 +1,35 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?>
-<target name="Eclipse 4.4.x (Luna)" sequenceNumber="43">
-   <locations>
-      <location includeAllPlatforms="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-         <unit id="com.android.ide.eclipse.adt.feature.feature.group" version="23.0.3.1327240"/>
-         <unit id="com.android.ide.eclipse.ddms.feature.feature.group" version="23.0.3.1327240"/>
-         <unit id="com.android.ide.eclipse.hierarchyviewer.feature.feature.group" version="23.0.3.1327240"/>
-         <unit id="com.android.ide.eclipse.traceview.feature.feature.group" version="23.0.3.1327240"/>
-         <repository location="https://dl-ssl.google.com/android/eclipse/"/>
-      </location>
-      <location includeAllPlatforms="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-         <unit id="org.junit" version="4.8.2.v4_8_2_v20110321-1705"/>
-         <repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20110523182458/repository/"/>
-      </location>
-      <location includeAllPlatforms="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-         <unit id="org.eclipse.m2e.feature.feature.group" version="1.5.0.20140606-0033"/>
-         <unit id="org.eclipse.m2e.sdk.feature.feature.group" version="1.5.0.20140606-0033"/>
-         <repository location="http://download.eclipse.org/technology/m2e/milestones/1.5"/>
-      </location>
-      <location includeAllPlatforms="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-         <unit id="org.eclipse.aether.feature.feature.group" version="1.0.0.v20140518"/>
-         <repository location="http://download.eclipse.org/aether/aether-core/releases/"/>
-      </location>
-      <location includeAllPlatforms="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-         <repository location="http://download.eclipse.org/releases/luna/"/>
-         <unit id="org.eclipse.sdk.ide" version="0.0.0"/>
-      </location>
-   </locations>
-   <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.6"/>
+<?pde version="3.8"?><target name="Eclipse 4.4.x (Luna)" sequenceNumber="48">
+<locations>
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="com.android.ide.eclipse.adt.feature.feature.group" version="23.0.3.1327240"/>
+<unit id="com.android.ide.eclipse.ddms.feature.feature.group" version="23.0.3.1327240"/>
+<unit id="com.android.ide.eclipse.hierarchyviewer.feature.feature.group" version="23.0.3.1327240"/>
+<unit id="com.android.ide.eclipse.traceview.feature.feature.group" version="23.0.3.1327240"/>
+<repository location="https://dl-ssl.google.com/android/eclipse/"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.sdk.ide" version="0.0.0"/>
+<repository location="http://download.eclipse.org/releases/luna/"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.aether.feature.feature.group" version="1.0.0.v20140518"/>
+<repository location="http://download.eclipse.org/aether/aether-core/releases/"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.m2e.feature.feature.group" version="1.5.0.20140606-0033"/>
+<unit id="org.eclipse.m2e.sdk.feature.feature.group" version="1.5.0.20140606-0033"/>
+<repository location="http://download.eclipse.org/technology/m2e/milestones/1.5"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.junit" version="4.11.0.v201303080030"/>
+<unit id="org.hamcrest" version="1.1.0.v20090501071000"/>
+<unit id="org.hamcrest.library" version="1.1.0.v20090501071000"/>
+<unit id="org.mockito" version="1.8.4.v201303031500"/>
+<unit id="org.hamcrest.integration" version="1.1.0.v201303031500"/>
+<unit id="org.hamcrest.generator" version="1.1.0.v20090501071000"/>
+<repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20130517111416/repository/"/>
+</location>
+</locations>
+<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.6"/>
 </target>

--- a/me.gladwell.eclipse.m2e.android.test/META-INF/MANIFEST.MF
+++ b/me.gladwell.eclipse.m2e.android.test/META-INF/MANIFEST.MF
@@ -14,13 +14,14 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.m2e.core;bundle-version="1.0.0",
  org.eclipse.m2e.maven.runtime;bundle-version="1.0.0",
  com.android.ide.eclipse.adt;bundle-version="21.0.0",
- org.junit;bundle-version="3.8.2",
  me.gladwell.eclipse.m2e.android;bundle-version="1.0.0",
  org.eclipse.jdt.launching;bundle-version="3.5.0",
  org.eclipse.m2e.archetype.common,
  com.android.ide.eclipse.base;bundle-version="21.0.0",
  org.eclipse.jdt.junit,
- org.eclipse.jdt.junit4.runtime
+ org.eclipse.jdt.junit4.runtime,
+ org.junit,
+ org.eclipse.m2e.jdt
 Bundle-ActivationPolicy: lazy
 Export-Package: me.gladwell.eclipse.m2e.android.test
 Import-Package: org.apache.maven.archetype.catalog,

--- a/me.gladwell.eclipse.m2e.android.test/src/me/gladwell/eclipse/m2e/android/test/AndroidMavenPluginTestCase.java
+++ b/me.gladwell.eclipse.m2e.android.test/src/me/gladwell/eclipse/m2e/android/test/AndroidMavenPluginTestCase.java
@@ -23,7 +23,6 @@ import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.IWorkspaceRunnable;
-import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;


### PR DESCRIPTION
Adds Junit 4.11 and Mockito as bundle dependencies for the target platforms.

Updates the test bundle to depend on org.junit 4.11 and adds org.mockito,
with required hamcrest bundles.

Updates all target platforms to bring in the necessary dependencies.