### PR TITLE
Fix AndroidMavenPluginTestCase#buildAndroidProject

### DIFF
--- a/me.gladwell.eclipse.m2e.android.test/src/me/gladwell/eclipse/m2e/android/test/AndroidMavenPluginTestCase.java
+++ b/me.gladwell.eclipse.m2e.android.test/src/me/gladwell/eclipse/m2e/android/test/AndroidMavenPluginTestCase.java
@@ -13,6 +13,7 @@ import static java.io.File.separator;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 import me.gladwell.eclipse.m2e.android.AndroidMavenPlugin;
@@ -165,7 +166,9 @@ public abstract class AndroidMavenPluginTestCase extends AbstractMavenProjectTes
 
     protected void buildAndroidProject(IProject project, int kind) throws CoreException, InterruptedException {
         ResourcesPlugin.getWorkspace().build(project.getBuildConfigs(), kind, true, monitor);
-        project.build(kind, "org.eclipse.jdt.core.javabuilder", null, monitor);
+        project.build(kind, "com.android.ide.eclipse.adt.ResourceManagerBuilder", new HashMap<String, String>(), monitor);
+        project.build(kind, "com.android.ide.eclipse.adt.PreCompilerBuilder", new HashMap<String, String>(), monitor);
+        project.build(kind, "org.eclipse.jdt.core.javabuilder", new HashMap<String, String>(), monitor);
     
         waitForJobsToComplete();
     }


### PR DESCRIPTION
When testing another features, i just realized `testTestRunner` no longer passes due to this (at least on Windows).
