### PR TITLE
Do not deploy with pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,4 +42,4 @@ script:
   - mvn verify -e --file me.gladwell.eclipse.m2e.android.test/pom.xml -Dtarget.platform=$TARGET_PLATFORM -Dtycho.showEclipseLog=true
 
 after_success:
-  - if [[ "$TARGET_PLATFORM" == "luna" ]]; then mvn -Dgithub.global.oauth2Token=$GITHUB_AUTH_TOKEN -pl me.gladwell.eclipse.m2e.android.update com.github.github:site-maven-plugin:site; fi
+  - if [[ $TRAVIS_PULL_REQUEST == "false" && $TARGET_PLATFORM == "luna" ]]; then mvn -Dgithub.global.oauth2Token=$GITHUB_AUTH_TOKEN -pl me.gladwell.eclipse.m2e.android.update com.github.github:site-maven-plugin:site; fi


### PR DESCRIPTION
Now every build wants to deploy to gh-pages, even pull-requests. PRs will of course fail, but this adds one minute extra time for the Luna build which is totally unnecessary. From now on, PR builds do not even try to deploy.
