### PR TITLE
Initial implementation using Andmore

### DIFF
--- a/me.gladwell.eclipse.m2e.android/META-INF/MANIFEST.MF
+++ b/me.gladwell.eclipse.m2e.android/META-INF/MANIFEST.MF
@@ -15,8 +15,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.m2e.jdt;bundle-version="1.0.0",
  org.eclipse.m2e.maven.runtime;bundle-version="1.0.0",
  org.eclipse.ui;bundle-version="3.5.0",
- com.android.ide.eclipse.adt;bundle-version="21.0.0",
- com.android.ide.eclipse.base;bundle-version="21.0.0",
+ org.eclipse.andmore,
+ org.eclipse.andmore.base,
  org.eclipse.debug.core,
  org.eclipse.jdt.junit.core
 Bundle-RequiredExecutionEnvironment: J2SE-1.5

--- a/me.gladwell.eclipse.m2e.android/src/main/java/me/gladwell/eclipse/m2e/android/AndroidMavenLaunchConfigurationListener.java
+++ b/me.gladwell.eclipse.m2e.android/src/main/java/me/gladwell/eclipse/m2e/android/AndroidMavenLaunchConfigurationListener.java
@@ -30,7 +30,7 @@ import org.eclipse.m2e.core.internal.IMavenConstants;
 import org.eclipse.m2e.core.project.IMavenProjectChangedListener;
 import org.eclipse.m2e.core.project.MavenProjectChangedEvent;
 
-import com.android.ide.eclipse.adt.AdtConstants;
+import org.eclipse.andmore.AdtConstants;
 
 public class AndroidMavenLaunchConfigurationListener implements ILaunchConfigurationListener,
         IMavenProjectChangedListener {

--- a/me.gladwell.eclipse.m2e.android/src/main/java/me/gladwell/eclipse/m2e/android/configuration/classpath/MarkAndroidClasspathContainerNotExportedConfigurer.java
+++ b/me.gladwell.eclipse.m2e.android/src/main/java/me/gladwell/eclipse/m2e/android/configuration/classpath/MarkAndroidClasspathContainerNotExportedConfigurer.java
@@ -11,7 +11,7 @@ package me.gladwell.eclipse.m2e.android.configuration.classpath;
 import me.gladwell.eclipse.m2e.android.project.EclipseAndroidProject;
 import me.gladwell.eclipse.m2e.android.project.MavenAndroidProject;
 
-import com.android.ide.eclipse.adt.AdtConstants;
+import org.eclipse.andmore.AdtConstants;
 
 public class MarkAndroidClasspathContainerNotExportedConfigurer implements ClasspathConfigurer {
 

--- a/me.gladwell.eclipse.m2e.android/src/main/java/me/gladwell/eclipse/m2e/android/configuration/workspace/OrderBuildersWorkspaceConfigurer.java
+++ b/me.gladwell.eclipse.m2e.android/src/main/java/me/gladwell/eclipse/m2e/android/configuration/workspace/OrderBuildersWorkspaceConfigurer.java
@@ -24,7 +24,7 @@ import org.eclipse.m2e.core.internal.IMavenConstants;
 
 public class OrderBuildersWorkspaceConfigurer implements WorkspaceConfigurer {
 
-    public static final String APK_BUILDER_COMMAND_NAME = "com.android.ide.eclipse.adt.ApkBuilder";
+    public static final String APK_BUILDER_COMMAND_NAME = "org.eclipse.andmore.ApkBuilder";
 
     public boolean isConfigured(EclipseAndroidProject project) {
         return false;

--- a/me.gladwell.eclipse.m2e.android/src/main/java/me/gladwell/eclipse/m2e/android/project/AdtEclipseAndroidProject.java
+++ b/me.gladwell.eclipse.m2e.android/src/main/java/me/gladwell/eclipse/m2e/android/project/AdtEclipseAndroidProject.java
@@ -33,10 +33,10 @@ import org.eclipse.m2e.core.project.configurator.AbstractProjectConfigurator;
 import org.eclipse.m2e.jdt.IClasspathDescriptor;
 
 import com.android.SdkConstants;
-import com.android.ide.eclipse.adt.AdtConstants;
-import com.android.ide.eclipse.adt.internal.project.ProjectHelper;
-import com.android.ide.eclipse.adt.internal.sdk.ProjectState;
-import com.android.ide.eclipse.adt.internal.sdk.Sdk;
+import org.eclipse.andmore.AdtConstants;
+import org.eclipse.andmore.internal.project.ProjectHelper;
+import org.eclipse.andmore.internal.sdk.ProjectState;
+import org.eclipse.andmore.internal.sdk.Sdk;
 import com.android.io.StreamException;
 import com.android.sdklib.internal.project.ProjectProperties;
 import com.android.sdklib.internal.project.ProjectPropertiesWorkingCopy;


### PR DESCRIPTION
This is proof of concept change to leverage the Andmore plugins instead
of ADT.  This will need some future work to allow for either module
to be injected depending on what plugins are installed.

This will fail to build until there is a public milestone of andmore available.  It is mainly here for discussion on how to support andmore and what current modifications are needed to use the renamed plugins.

