### PR TITLE
Integrate with JRebel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ pom.xml.*
 #Other
 .vagrant
 .checkstyle
+rebel.xml

--- a/me.gladwell.eclipse.m2e.android.test/[me.gladwell.eclipse.m2e.android.test] test.launch
+++ b/me.gladwell.eclipse.m2e.android.test/[me.gladwell.eclipse.m2e.android.test] test.launch
@@ -32,7 +32,7 @@
 <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="me.gladwell.eclipse.m2e.android.test"/>
 <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
-<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dosgi.requiredJavaVersion=1.5 -XX:MaxPermSize=256m -Xms40m -Xmx512m ${env_var:MAVEN_OPTS}"/>
+<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="${jrebel_args} -Dosgi.requiredJavaVersion=1.5 -XX:MaxPermSize=256m -Xms40m -Xmx512m ${env_var:MAVEN_OPTS}"/>
 <stringAttribute key="pde.version" value="3.3"/>
 <stringAttribute key="product" value="org.eclipse.platform.ide"/>
 <booleanAttribute key="run_in_ui_thread" value="true"/>

--- a/me.gladwell.eclipse.m2e.android/[me.gladwell.eclipse.m2e.android] run.launch
+++ b/me.gladwell.eclipse.m2e.android/[me.gladwell.eclipse.m2e.android] run.launch
@@ -20,7 +20,7 @@
 <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog"/>
 <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
-<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dosgi.requiredJavaVersion=1.5 -Xms40m -Xmx2048m -XX:MaxPermSize=2048m ${env_var:MAVEN_OPTS}"/>
+<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="${jrebel_args} -Dosgi.requiredJavaVersion=1.5 -Xms40m -Xmx2048m -XX:MaxPermSize=2048m ${env_var:MAVEN_OPTS}"/>
 <stringAttribute key="pde.version" value="3.3"/>
 <stringAttribute key="product" value="org.eclipse.platform.ide"/>
 <booleanAttribute key="show_selected_only" value="false"/>


### PR DESCRIPTION
JRebel is a tool which enables advanced hot code replacement in almost every situations (when the traditional replacement technic fails), thus removes the need of redeploying the plugin when debugging. This commit adds the necessary VM argument to the run configurations, and adds the rebel.xml file to the git ignore list. It does not effect developers who do not use JRebel.

You can read the JRebel installation instruction [here](http://zeroturnaround.com/software/jrebel/quickstart/eclipse/) and get a free license [here](https://my.jrebel.com/) (for development of open source software).