### PR TITLE
Print some logs at debug level

### DIFF
--- a/me.gladwell.eclipse.m2e.android.test/src/me/gladwell/eclipse/m2e/android/test/AndroidMavenPluginTestCase.java
+++ b/me.gladwell.eclipse.m2e.android.test/src/me/gladwell/eclipse/m2e/android/test/AndroidMavenPluginTestCase.java
@@ -233,7 +233,7 @@ public abstract class AndroidMavenPluginTestCase extends AbstractMavenProjectTes
             }
         }
 
-        throw new RuntimeException("ClasspathEntry [" + path + "] nt found in container [" + id + "]");
+        throw new RuntimeException("ClasspathEntry [" + path + "] not found in container [" + id + "]");
     }
 
     protected void assertErrorMarker(IProject project, String type) throws CoreException {

--- a/me.gladwell.eclipse.m2e.android.test/src/me/gladwell/eclipse/m2e/android/test/AndroidMavenPluginTestCase.java
+++ b/me.gladwell.eclipse.m2e.android.test/src/me/gladwell/eclipse/m2e/android/test/AndroidMavenPluginTestCase.java
@@ -216,12 +216,15 @@ public abstract class AndroidMavenPluginTestCase extends AbstractMavenProjectTes
     }
 
     protected boolean classpathContainerContains(IJavaProject project, String id, String path) throws JavaModelException {
-        try {
-            return getClasspathEntry(project, id, path) != null;
-        } catch (Exception e) {
-            e.printStackTrace();
-            return false;
+        IClasspathContainer container = JavaCore.getClasspathContainer(new Path(id), project);
+
+        for (IClasspathEntry entry : container.getClasspathEntries()) {
+            if (entry.getPath().toOSString().contains(path)) {
+                return true;
+            }
         }
+        
+        return false;
     }
     
     protected IClasspathEntry getClasspathEntry(IJavaProject project, String id, String path) throws JavaModelException {

--- a/me.gladwell.eclipse.m2e.android/src/main/java/me/gladwell/eclipse/m2e/android/Log.java
+++ b/me.gladwell.eclipse.m2e.android/src/main/java/me/gladwell/eclipse/m2e/android/Log.java
@@ -32,5 +32,11 @@ public class Log {
             log.log(status(Status.INFO, "[DEBUG] " + message));
         }
     }
+    
+    public static void debug(String message, Throwable t) {
+        if(DEBUG) {
+            log.log(status(Status.INFO, "[DEBUG] " + message, t));
+        }
+    }
 
 }

--- a/me.gladwell.eclipse.m2e.android/src/main/java/me/gladwell/eclipse/m2e/android/configuration/ClasspathAttacher.java
+++ b/me.gladwell.eclipse.m2e.android/src/main/java/me/gladwell/eclipse/m2e/android/configuration/ClasspathAttacher.java
@@ -92,7 +92,7 @@ public class ClasspathAttacher<T extends EntryAttacher> {
                     }
 
                 } catch (Exception e) {
-                    warn("could not resolve " + classifier + " for classpath entry=[" + entry + "]", e);
+                    debug("could not resolve " + classifier + " for classpath entry=[" + entry + "]", e);
                     processed.add(entry);
                 }
             }


### PR DESCRIPTION
In 99% of the cases, these events are expected, so log them at debug level instead of showing them always.