### PR TITLE
Update targets for m2e 1.6 release

### DIFF
--- a/andmore/andmore.target
+++ b/andmore/andmore.target
@@ -9,7 +9,7 @@
       <location includeAllPlatforms="false" includeMode="planner" includeSource="true" type="InstallableUnit">
         <unit id="org.eclipse.m2e.feature.feature.group" version="1.6.0.20150526-2032"/>
         <unit id="org.eclipse.m2e.sdk.feature.feature.group" version="1.6.0.20150526-2032"/>
-        <repository location="http://download.eclipse.org/technology/m2e/milestones/1.6"/>
+        <repository location="http://download.eclipse.org/technology/m2e/releases/1.6/"/>
       </location>
       <location includeAllPlatforms="false" includeMode="planner" includeSource="true" type="InstallableUnit">
          <repository location="http://download.eclipse.org/releases/mars/"/>

--- a/compile/compile.target
+++ b/compile/compile.target
@@ -12,7 +12,7 @@
       <location includeAllPlatforms="false" includeMode="planner" includeSource="true" type="InstallableUnit">
         <unit id="org.eclipse.m2e.feature.feature.group" version="1.6.0.20150526-2032"/>
         <unit id="org.eclipse.m2e.sdk.feature.feature.group" version="1.6.0.20150526-2032"/>
-        <repository location="http://download.eclipse.org/technology/m2e/milestones/1.6"/>
+        <repository location="http://download.eclipse.org/technology/m2e/releases/1.6/"/>
       </location>
       <location includeAllPlatforms="false" includeMode="planner" includeSource="true" type="InstallableUnit">
         <repository location="http://download.eclipse.org/releases/mars/"/>

--- a/mars/mars.target
+++ b/mars/mars.target
@@ -12,7 +12,7 @@
       <location includeAllPlatforms="false" includeMode="planner" includeSource="true" type="InstallableUnit">
          <unit id="org.eclipse.m2e.feature.feature.group" version="1.6.0.20150526-2032"/>
          <unit id="org.eclipse.m2e.sdk.feature.feature.group" version="1.6.0.20150526-2032"/>
-         <repository location="http://download.eclipse.org/technology/m2e/milestones/1.6"/>
+         <repository location="http://download.eclipse.org/technology/m2e/releases/1.6/"/>
       </location>
       <location includeAllPlatforms="false" includeMode="planner" includeSource="true" type="InstallableUnit">
          <repository location="http://download.eclipse.org/releases/mars/"/>


### PR DESCRIPTION
M2Eclipse 1.6 was released, so we should use the release update site instead of the milestone one.